### PR TITLE
Fixes for deprecated github actions node12 and set-output commands

### DIFF
--- a/.devcontainer/build.sh
+++ b/.devcontainer/build.sh
@@ -8,8 +8,8 @@ mkp -v pack $NAME
 
 # Set Outputs for GitHub Workflow steps
 if [ -n "$GITHUB_WORKSPACE" ]; then
-    echo "::set-output name=pkgfile::$(ls *.mkp)"
-    echo "::set-output name=pkgname::${NAME}"
+    echo "pkgfile=$(ls *.mkp)" >> $GITHUB_OUTPUT
+    echo "pkgname=${NAME}" >> $GITHUB_OUTPUT
     VERSION=$(python -c 'print(eval(open("package").read())["version"])')
-    echo "::set-output name=pkgversion::$VERSION"
+    echo "pkgversion=$VERSION"  >> $GITHUB_OUTPUT
 fi

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Initialize Checkmk Site
         run: /docker-entrypoint.sh /bin/true
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup links
         run: .devcontainer/symlink.sh
       - name: Update GITHUB_PATH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Initialize Checkmk Site
         run: /docker-entrypoint.sh /bin/true
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup links
         run: .devcontainer/symlink.sh
       - name: Update GITHUB_PATH
@@ -33,7 +33,7 @@ jobs:
         run: .devcontainer/build.sh
         id: cmkpkg
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.cmkpkg.outputs.pkgfile }}
           path: ${{ steps.cmkpkg.outputs.pkgfile }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
     - name: Install flake8

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - name: Initialize Checkmk Site
       run: /docker-entrypoint.sh /bin/true
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup links
       run: ./.devcontainer/symlink.sh
     - name: Install pytest


### PR DESCRIPTION
Some fixes to get rid of the node12 deprecation warnings of github actions.
Migrations for deprecated "set-output" commands.
