### PR TITLE
Suggestion for renaming for IS-IS rename see #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Description
 
- * isis_adjacency discovers and checks the status of ISIS adjacency for ISIS-MIB
+ * isis_adjacency discovers and checks the status of IS-IS adjacency for [ISIS-MIB](https://datatracker.ietf.org/doc/html/rfc4444)
 
 ## Development
 

--- a/agent_based/isis_adjacency.py
+++ b/agent_based/isis_adjacency.py
@@ -120,7 +120,7 @@ def check_isis_adjacency(item, section):
 
 register.check_plugin(
     name='isis_adjacency',
-    service_name='ISIS Status Neighbor %s',
+    service_name='IS-IS Status Neighbor %s',
     discovery_function=discover_isis_adjacency,
     check_function=check_isis_adjacency,
 )


### PR DESCRIPTION
Hey,

this would be my suggestion for a surgically minimal invasive rename in our discussion in #4 .
This way the plugin stays API compatible I hope (?).

Unfortunately the MIB is really called ISIS-MIB, so calling it differently would be wrong.

What do you think?

Stephan