### PR TITLE
Adds discovery rule, to limit discovery of IS-IS Status neighbors to specific subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Description
 
  * isis_adjacency discovers and checks the status of IS-IS adjacency for [ISIS-MIB](https://datatracker.ietf.org/doc/html/rfc4444)
-
+ * service discovery can be limited to IS-IS neighbors within specific subnets
 ## Development
 
 For the best development experience use [VSCode](https://code.visualstudio.com/) with the [Remote Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension. This maps your workspace into a checkmk docker container giving you access to the python environment and libraries the installed extension has.

--- a/web/plugins/wato/isis_adjacency_params.py
+++ b/web/plugins/wato/isis_adjacency_params.py
@@ -1,0 +1,80 @@
+from ipaddress import ip_network
+from typing import List
+from cmk.gui.plugins.wato.utils import (
+    HostRulespec,
+    RulespecGroupCheckParametersDiscovery,
+    rulespec_registry,
+)
+from cmk.gui.valuespec import (
+    Dictionary,
+    Checkbox,
+    ListOfStrings,
+    Labels,
+    MKUserError,
+)
+from cmk.gui.i18n import _
+
+
+def _validate_spec_subnet(value: List, varprefix) -> bool:
+    for subnet in value:
+        try:
+            ip_network(subnet)
+        except ValueError as e:
+            raise MKUserError(
+                varprefix,
+                _(f"{e}"),
+            )
+    return True
+
+def _parameter_valuespec_isis_adjacency_discovery() -> Dictionary:
+    return Dictionary(
+        required_keys=["subnets"],
+        elements=[
+            (
+                "subnets",
+                Dictionary(
+                    required_keys=["subnets", "negate"],
+                    elements=[
+                        (
+                            "subnets",
+                            ListOfStrings(
+                                title=_("Subnets"),
+                                allow_empty=False,
+                                validate=_validate_spec_subnet,
+                                help=_('If an IS-IS neighbor is within specified subnets, it will get discovered.'),
+                            )
+                        ),
+                        (
+                            "negate",
+                            Checkbox(
+                                title=_("Negate"),
+                                help=_("Negate the subnet match. If checked, the rule will match if the IS-IS neighbor is not within the specified subnets."),
+                                true_label=_("negated"),
+                                default_value=False,
+                            ),
+                        ),
+                    ]
+                )
+            ),
+            (
+                "labels",
+                Labels(
+                    title=_("Discovery label"),
+                    world=Labels.World.CONFIG,
+                    label_source=Labels.Source.RULESET,
+                    help=_("Labels to be assigned to the discovered services."),
+                ),
+            ),
+        ]
+    )
+
+
+rulespec_registry.register(
+    HostRulespec(
+        group=RulespecGroupCheckParametersDiscovery,
+        match_type="dict",
+        name="isis_adjacency_discovery",
+        valuespec=_parameter_valuespec_isis_adjacency_discovery,
+        title=lambda: _("IS-IS Neighbor discovery"),
+    )
+)


### PR DESCRIPTION
* adds "IS-IS Neighbor discovery" in Network section of checkmk's service discovery rules
  * can limit discovery of IS-IS neighbors to specific subnets
  * can add service labels during discovery